### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This Vite plugin support `<preview lang="md">` custom block in SFC for preview s
 	<button @click="count++">count is: {{ count }}</button>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue'
 
 defineProps<{ msg: string }>()


### PR DESCRIPTION
Add `lang="ts"` because a type was used in `defineProps<{ msg: string }>()` .