### PR TITLE
Fix bug when using "base" URI

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -4,9 +4,9 @@ export default function (app: App) {
 
 	const location = globalThis.location;
 
-	if (location && location.pathname.startsWith('/__preview/')) {
+	if (location && location.pathname.startsWith(globalThis.preview.base + '__preview/')) {
 
-		const importPath = location.pathname.substring('/__preview'.length);
+		const importPath = location.pathname.replace('__preview/', '');
 		const Component = defineAsyncComponent(() => import(/* @vite-ignore */importPath));
 		const Layout = defineAsyncComponent(() => import(/* @vite-ignore */importPath + '__preview.vue'));
 

--- a/client/index.ts
+++ b/client/index.ts
@@ -4,7 +4,7 @@ export default function (app: App) {
 
 	const location = globalThis.location;
 
-    if (location && location.pathname.includes('/__preview/')) {
+	if (location && location.pathname.includes('/__preview/')) {
 
 		const importPath = location.pathname.replace('/__preview', '');
 		const Component = defineAsyncComponent(() => import(/* @vite-ignore */importPath));

--- a/client/index.ts
+++ b/client/index.ts
@@ -4,9 +4,9 @@ export default function (app: App) {
 
 	const location = globalThis.location;
 
-	if (location && location.pathname.includes('__preview/')) {
+    if (location && location.pathname.includes('/__preview/')) {
 
-		const importPath = location.pathname.replace('__preview/', '');
+		const importPath = location.pathname.replace('/__preview', '');
 		const Component = defineAsyncComponent(() => import(/* @vite-ignore */importPath));
 		const Layout = defineAsyncComponent(() => import(/* @vite-ignore */importPath + '__preview.vue'));
 

--- a/client/index.ts
+++ b/client/index.ts
@@ -4,7 +4,7 @@ export default function (app: App) {
 
 	const location = globalThis.location;
 
-	if (location && location.pathname.startsWith(globalThis.preview.base + '__preview/')) {
+	if (location && location.pathname.includes('__preview/')) {
 
 		const importPath = location.pathname.replace('__preview/', '');
 		const Component = defineAsyncComponent(() => import(/* @vite-ignore */importPath));

--- a/index.ts
+++ b/index.ts
@@ -15,11 +15,6 @@ export default function vuePreviewPlugin(): Plugin {
 
 	return {
 		name: 'vite-plugin-vue-component-preview',
-		configResolved(config){
-			config.define.preview = {
-				base: config.base
-			}
-		},
 		configureServer(_server) {
 			server = _server;
 			server.middlewares.use((req, res, next) => {

--- a/index.ts
+++ b/index.ts
@@ -15,11 +15,16 @@ export default function vuePreviewPlugin(): Plugin {
 
 	return {
 		name: 'vite-plugin-vue-component-preview',
+		configResolved(config){
+			config.define.preview = {
+				base: config.base
+			}
+		},
 		configureServer(_server) {
 			server = _server;
 			server.middlewares.use((req, res, next) => {
-				if (req.url?.startsWith('/__preview/')) {
-					req.url = '/'; // avoid 404
+				if (req.url?.startsWith(server.config.base + '__preview/')) {
+					req.url = server.config.base; // avoid 404
 				}
 				next();
 			});


### PR DESCRIPTION
Hi guys,

With my team we works behind a base URI and it seem's to be not compatible with your plugin. The plugin always respond with a 404 status.

After some experiments, I found out that the base URI is not considered in the plugin.

Here is a pull request that seems to fix the problem.

I'm not familiar with vite and vue plugins so you can make any modification to be more correct.

Hope you will accept this request!