### PR TITLE
fix: move `return id` inside if statement

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -42,8 +42,8 @@ export default function vuePreviewPlugin(): Plugin {
 				!cleanId.startsWith(server.config.root)
 			) {
 				id = path.join(server.config.root, id);
+				return id;
 			}
-			return id;
 		},
 		load(id) {
 			if (id.endsWith('__preview.vue')) {


### PR DESCRIPTION
Move `return id` inside if statement so handler is only handling preview pages and nothing else. 
This solves conflict with `dynamicRoutes` in `vitepress`

https://github.com/vuejs/vitepress/blob/main/src/node/plugins/dynamicRoutesPlugin.ts#L98